### PR TITLE
Move to GitOps Config File

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ There is another companion action [github-action-atmos-terraform-drift-detection
 
 ### Config
 
-The action expects the atmos gitops configuration file to be present in the repository in `./.github/atmos-gitops.yaml`.
+The action expects the atmos gitops configuration file to be present in the repository in `./.github/config/atmos-gitops.yaml`.
 The config should have the following structure:
 
 ```yaml
@@ -148,7 +148,7 @@ jobs:
 
 `v2` drop `component-path` variable. Now it fetches from `atmos.yaml` file automatically.
 
-`v2` moved variables from `inputs` to atmos gitops config path `./.github/atmos-gitops.yaml`
+`v2` moved variables from `inputs` to atmos gitops config path `./.github/config/atmos-gitops.yaml`
 
 |         name             |
 |--------------------------|
@@ -164,7 +164,7 @@ jobs:
 | `enable-infracost`       |
 
 
-If you want `v2` having the same behaviour as `v1` you should create config `./.github/atmos-gitops.yaml` with the same variables as in `v1` inputs.
+If you want `v2` having the same behaviour as `v1` you should create config `./.github/config/atmos-gitops.yaml` with the same variables as in `v1` inputs.
 
 ```yaml
   - name: Remediate Drift
@@ -172,7 +172,7 @@ If you want `v2` having the same behaviour as `v1` you should create config `./.
     with:
       issue-number: ${{ github.event.issue.number }}
       action: remediate
-      atmos-gitops-config-path: ./.github/atmos-gitops.yaml  
+      atmos-gitops-config-path: ./.github/config/atmos-gitops.yaml  
 ```
 
 same behaviour as

--- a/README.md
+++ b/README.md
@@ -35,14 +35,6 @@ This Github Action is used to remediate drift
 ---
 
 This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
-[<img align="right" title="Share via Email" src="https://docs.cloudposse.com/images/ionicons/ios-email-outline-2.0.1-16x16-999999.svg"/>][share_email]
-[<img align="right" title="Share on Google+" src="https://docs.cloudposse.com/images/ionicons/social-googleplus-outline-2.0.1-16x16-999999.svg" />][share_googleplus]
-[<img align="right" title="Share on Facebook" src="https://docs.cloudposse.com/images/ionicons/social-facebook-outline-2.0.1-16x16-999999.svg" />][share_facebook]
-[<img align="right" title="Share on Reddit" src="https://docs.cloudposse.com/images/ionicons/social-reddit-outline-2.0.1-16x16-999999.svg" />][share_reddit]
-[<img align="right" title="Share on LinkedIn" src="https://docs.cloudposse.com/images/ionicons/social-linkedin-outline-2.0.1-16x16-999999.svg" />][share_linkedin]
-[<img align="right" title="Share on Twitter" src="https://docs.cloudposse.com/images/ionicons/social-twitter-outline-2.0.1-16x16-999999.svg" />][share_twitter]
-
-
 
 
 It's 100% Open Source and licensed under the [APACHE2](LICENSE).
@@ -63,8 +55,6 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 This action is used for drift remediation.
 
 There is another companion action [github-action-atmos-terraform-drift-detection](https://github.com/cloudposse/github-action-atmos-terraform-drift-detection).
-
-
 
 
 
@@ -91,6 +81,9 @@ The config should have the following structure:
   sort-by: .stack_slug
   group-by: .stack_slug | split("-") | [.[0], .[2]] | join("-")  
 ```
+
+> [!IMPORTANT]
+> **Please note!** the `terraform-state-*` parameters refer to the S3 Bucket and corresponding meta storage DynamoDB table used to store the Terraform Plan files, and not the "Terraform State". These parameters will be renamed in a subsequent release.  
 
 ### Workflow example
 
@@ -119,16 +112,11 @@ jobs:
       contains(join(github.event.issue.labels.*.name, ','), 'apply')
     steps:
       - name: Remediate Drift
-        uses: cloudposse/github-action-atmos-terraform-drift-remediation@v2
+        uses: cloudposse/github-action-atmos-terraform-drift-remediation@v1
         with:
           issue-number: ${{ github.event.issue.number }}
           action: remediate
-          atmos-config-path: "${{ github.workspace }}/rootfs/usr/local/etc/atmos/"
-          terraform-plan-role: "arn:aws:iam::111111111111:role/acme-core-gbl-identity-gitops"
-          terraform-state-bucket: "acme-core-ue2-auto-gitops"
-          terraform-state-role: "arn:aws:iam::999999999999:role/acme-core-ue2-auto-gitops-gha"
-          terraform-state-table: "acme-core-ue2-auto-gitops"
-          aws-region: "us-east-2"
+          atmos-gitops-config-path: ./.github/config/atmos-gitops.yaml
 
   discard-drift:
     runs-on: ubuntu-latest
@@ -138,17 +126,17 @@ jobs:
       !contains(join(github.event.issue.labels.*.name, ','), 'remediated')
     steps:
       - name: Discard Drift
-        uses: cloudposse/github-action-atmos-terraform-drift-remediation@v2
+        uses: cloudposse/github-action-atmos-terraform-drift-remediation@v1
         with:
           issue-number: ${{ github.event.issue.number }}
           action: discard
+          atmos-gitops-config-path: ./.github/config/atmos-gitops.yaml    
 ```
 
-### Migrating from `v1` to `v2`
+### Migrating from `v0` to `v1`
 
-`v2` drop `component-path` variable. Now it fetches from `atmos.yaml` file automatically.
-
-`v2` moved variables from `inputs` to atmos gitops config path `./.github/config/atmos-gitops.yaml`
+1.  `v2` drops the `component-path` variable and instead fetches if directly from the [`atmos.yaml` file](https://atmos.tools/cli/configuration/) automatically. Simply remove the `component-path` argument from your invocations of the `cloudposse/github-action-atmos-terraform-plan` action.
+2.  `v2` moves most of the `inputs` to the Atmos GitOps config path `./.github/config/atmos-gitops.yaml`. Simply create this file, transfer your settings to it, then remove the corresponding arguments from your invocations of the `cloudposse/github-action-atmos-terraform-plan` action.  
 
 |         name             |
 |--------------------------|
@@ -164,22 +152,22 @@ jobs:
 | `enable-infracost`       |
 
 
-If you want the same behavior in `v2`  as in`v1` you should create config `./.github/config/atmos-gitops.yaml` with the same variables as in `v1` inputs.
+If you want the same behavior in `v1`  as in`v0` you should create config `./.github/config/atmos-gitops.yaml` with the same variables as in `v0` inputs.
 
 ```yaml
   - name: Remediate Drift
-    uses: cloudposse/github-action-atmos-terraform-drift-remediation@v2
+    uses: cloudposse/github-action-atmos-terraform-drift-remediation@v1
     with:
       issue-number: ${{ github.event.issue.number }}
       action: remediate
       atmos-gitops-config-path: ./.github/config/atmos-gitops.yaml  
 ```
 
-same behaviour as
+ Which would produce the same behavior as in `v0`, doing this:
 
 ```yaml
   - name: Remediate Drift
-    uses: cloudposse/github-action-atmos-terraform-drift-remediation@v1
+    uses: cloudposse/github-action-atmos-terraform-drift-remediation@v0
     with:
       issue-number: ${{ github.event.issue.number }}
       action: remediate
@@ -212,15 +200,6 @@ same behaviour as
 <!-- markdownlint-restore -->
 
 
-
-## Share the Love
-
-Like this project? Please give it a ★ on [our GitHub](https://github.com/cloudposse/github-action-atmos-terraform-drift-remediation)! (it helps us **a lot**)
-
-Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
-
-
-
 ## Related Projects
 
 Check out these related projects.
@@ -238,16 +217,49 @@ For additional context, refer to some of these links.
 - [github-action-terraform-apply](https://github.com/cloudposse/github-action-atmos-terraform-apply) - GitHub Action to do Terraform Apply
 
 
-## Help
+## ✨ Contributing
 
-**Got a question?** We got answers.
+This project is under active development, and we encourage contributions from our community. 
+Many thanks to our outstanding contributors:
 
-File a GitHub [issue](https://github.com/cloudposse/github-action-atmos-terraform-drift-remediation/issues), send us an [email][email] or join our [Slack Community][slack].
+<a href="https://github.com/cloudposse/github-action-atmos-terraform-drift-remediation/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=cloudposse/github-action-atmos-terraform-drift-remediation&max=24" />
+</a>
 
-[![README Commercial Support][readme_commercial_support_img]][readme_commercial_support_link]
+### 🐛 Bug Reports & Feature Requests
 
-## DevOps Accelerator for Startups
+Please use the [issue tracker](https://github.com/cloudposse/github-action-atmos-terraform-drift-remediation/issues) to report any bugs or file feature requests.
 
+### 💻 Developing
+
+If you are interested in being a contributor and want to get involved in developing this project or [help out](https://cpco.io/help-out) with our other projects, we would love to hear from you! Shoot us an [email][email].
+
+In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
+
+ 1. **Fork** the repo on GitHub
+ 2. **Clone** the project to your own machine
+ 3. **Commit** changes to your own branch
+ 4. **Push** your work back up to your fork
+ 5. Submit a **Pull Request** so that we can review your changes
+
+**NOTE:** Be sure to merge the latest changes from "upstream" before making a pull request!
+
+### 🌎 Slack Community
+
+Join our [Open Source Community][slack] on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
+
+### 📰 Newsletter
+
+Sign up for [our newsletter][newsletter] that covers everything on our technology radar.  Receive updates on what we're up to on GitHub as well as awesome new projects we discover.
+
+### 📆 Office Hours <img src="https://img.cloudposse.com/fit-in/200x200/https://cloudposse.com/wp-content/uploads/2019/08/Powered-by-Zoom.png" align="right" />
+
+[Join us every Wednesday via Zoom][office_hours] for our weekly "Lunch & Learn" sessions. It's **FREE** for everyone!
+
+## About 
+
+This project is maintained and funded by [Cloud Posse, LLC][website]. 
+<a href="https://cpco.io/homepage"><img src="https://cloudposse.com/logo-300x69.svg" align="right" /></a>
 
 We are a [**DevOps Accelerator**][commercial_support]. We'll help you build your cloud infrastructure from the ground up so you can own it. Then we'll show you how to operate it and stick around for as long as you need us.
 
@@ -268,51 +280,7 @@ We deliver 10x the value for a fraction of the cost of a full-time engineer. Our
 - **Code Reviews.** You'll receive constructive feedback on Pull Requests.
 - **Bug Fixes.** We'll rapidly work with you to fix any bugs in our projects.
 
-## Slack Community
-
-Join our [Open Source Community][slack] on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
-
-## Discourse Forums
-
-Participate in our [Discourse Forums][discourse]. Here you'll find answers to commonly asked questions. Most questions will be related to the enormous number of projects we support on our GitHub. Come here to collaborate on answers, find solutions, and get ideas about the products and services we value. It only takes a minute to get started! Just sign in with SSO using your GitHub account.
-
-## Newsletter
-
-Sign up for [our newsletter][newsletter] that covers everything on our technology radar.  Receive updates on what we're up to on GitHub as well as awesome new projects we discover.
-
-## Office Hours
-
-[Join us every Wednesday via Zoom][office_hours] for our weekly "Lunch & Learn" sessions. It's **FREE** for everyone!
-
-[![zoom](https://img.cloudposse.com/fit-in/200x200/https://cloudposse.com/wp-content/uploads/2019/08/Powered-by-Zoom.png")][office_hours]
-
-## Contributing
-
-### Bug Reports & Feature Requests
-
-Please use the [issue tracker](https://github.com/cloudposse/github-action-atmos-terraform-drift-remediation/issues) to report any bugs or file feature requests.
-
-### Developing
-
-If you are interested in being a contributor and want to get involved in developing this project or [help out](https://cpco.io/help-out) with our other projects, we would love to hear from you! Shoot us an [email][email].
-
-In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
-
- 1. **Fork** the repo on GitHub
- 2. **Clone** the project to your own machine
- 3. **Commit** changes to your own branch
- 4. **Push** your work back up to your fork
- 5. Submit a **Pull Request** so that we can review your changes
-
-**NOTE:** Be sure to merge the latest changes from "upstream" before making a pull request!
-
-
-## Copyright
-
-Copyright © 2017-2023 [Cloud Posse, LLC](https://cpco.io/copyright)
-
-
-
+[![README Commercial Support][readme_commercial_support_img]][readme_commercial_support_link]
 ## License
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
@@ -338,46 +306,11 @@ specific language governing permissions and limitations
 under the License.
 ```
 
-
-
-
-
-
-
-
-
 ## Trademarks
 
 All other trademarks referenced herein are the property of their respective owners.
-
-## About
-
-This project is maintained and funded by [Cloud Posse, LLC][website]. Like it? Please let us know by [leaving a testimonial][testimonial]!
-
-[![Cloud Posse][logo]][website]
-
-We're a [DevOps Professional Services][hire] company based in Los Angeles, CA. We ❤️  [Open Source Software][we_love_open_source].
-
-We offer [paid support][commercial_support] on all of our projects.
-
-Check out [our other projects][github], [follow us on twitter][twitter], [apply for a job][jobs], or [hire us][hire] to help with your cloud strategy and implementation.
-
-
-
-### Contributors
-
-<!-- markdownlint-disable -->
-|  [![Zinovii Dmytriv][zdmytriv_avatar]][zdmytriv_homepage]<br/>[Zinovii Dmytriv][zdmytriv_homepage] | [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Daniel Miller][milldr_avatar]][milldr_homepage]<br/>[Daniel Miller][milldr_homepage] |
-|---|---|---|
-<!-- markdownlint-restore -->
-
-  [zdmytriv_homepage]: https://github.com/zdmytriv
-  [zdmytriv_avatar]: https://img.cloudposse.com/150x150/https://github.com/zdmytriv.png
-  [osterman_homepage]: https://github.com/osterman
-  [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
-  [milldr_homepage]: https://github.com/milldr
-  [milldr_avatar]: https://img.cloudposse.com/150x150/https://github.com/milldr.png
-
+---
+Copyright © 2017-2023 [Cloud Posse, LLC](https://cpco.io/copyright)
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
 <!-- markdownlint-disable -->
@@ -388,12 +321,9 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [jobs]: https://cpco.io/jobs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-terraform-drift-remediation&utm_content=jobs
   [hire]: https://cpco.io/hire?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-terraform-drift-remediation&utm_content=hire
   [slack]: https://cpco.io/slack?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-terraform-drift-remediation&utm_content=slack
-  [linkedin]: https://cpco.io/linkedin?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-terraform-drift-remediation&utm_content=linkedin
   [twitter]: https://cpco.io/twitter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-terraform-drift-remediation&utm_content=twitter
-  [testimonial]: https://cpco.io/leave-testimonial?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-terraform-drift-remediation&utm_content=testimonial
   [office_hours]: https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-terraform-drift-remediation&utm_content=office_hours
   [newsletter]: https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-terraform-drift-remediation&utm_content=newsletter
-  [discourse]: https://ask.sweetops.com/?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-terraform-drift-remediation&utm_content=discourse
   [email]: https://cpco.io/email?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-terraform-drift-remediation&utm_content=email
   [commercial_support]: https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-terraform-drift-remediation&utm_content=commercial_support
   [we_love_open_source]: https://cpco.io/we-love-open-source?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-terraform-drift-remediation&utm_content=we_love_open_source
@@ -404,11 +334,5 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [readme_footer_link]: https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-terraform-drift-remediation&utm_content=readme_footer_link
   [readme_commercial_support_img]: https://cloudposse.com/readme/commercial-support/img
   [readme_commercial_support_link]: https://cloudposse.com/readme/commercial-support/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-terraform-drift-remediation&utm_content=readme_commercial_support_link
-  [share_twitter]: https://twitter.com/intent/tweet/?text=github-action-atmos-terraform-drift-remediation&url=https://github.com/cloudposse/github-action-atmos-terraform-drift-remediation
-  [share_linkedin]: https://www.linkedin.com/shareArticle?mini=true&title=github-action-atmos-terraform-drift-remediation&url=https://github.com/cloudposse/github-action-atmos-terraform-drift-remediation
-  [share_reddit]: https://reddit.com/submit/?url=https://github.com/cloudposse/github-action-atmos-terraform-drift-remediation
-  [share_facebook]: https://facebook.com/sharer/sharer.php?u=https://github.com/cloudposse/github-action-atmos-terraform-drift-remediation
-  [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/github-action-atmos-terraform-drift-remediation
-  [share_email]: mailto:?subject=github-action-atmos-terraform-drift-remediation&body=https://github.com/cloudposse/github-action-atmos-terraform-drift-remediation
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/github-action-atmos-terraform-drift-remediation?pixel&cs=github&cm=readme&an=github-action-atmos-terraform-drift-remediation
 <!-- markdownlint-restore -->

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ jobs:
           action: discard
 ```
 
-### Migrate from `v1` to `v2`
+### Migrating from `v1` to `v2`
 
 `v2` drop `component-path` variable. Now it fetches from `atmos.yaml` file automatically.
 
@@ -164,7 +164,7 @@ jobs:
 | `enable-infracost`       |
 
 
-If you want `v2` having the same behaviour as `v1` you should create config `./.github/config/atmos-gitops.yaml` with the same variables as in `v1` inputs.
+If you want the same behavior in `v2`  as in`v1` you should create config `./.github/config/atmos-gitops.yaml` with the same variables as in `v1` inputs.
 
 ```yaml
   - name: Remediate Drift

--- a/README.md
+++ b/README.md
@@ -72,6 +72,26 @@ There is another companion action [github-action-atmos-terraform-drift-detection
 
 
 
+### Config
+
+The action expects the atmos gitops configuration file to be present in the repository in `./.github/atmos-gitops.yaml`.
+The config should have the following structure:
+
+```yaml
+  atmos-version: 1.45.3
+  atmos-config-path: ./rootfs/usr/local/etc/atmos/
+  terraform-state-bucket: cptest-core-ue2-auto-gitops
+  terraform-state-table: cptest-core-ue2-auto-gitops
+  terraform-state-role: arn:aws:iam::xxxxxxxxxxxx:role/cptest-core-ue2-auto-gitops-gha
+  terraform-plan-role: arn:aws:iam::yyyyyyyyyyyy:role/cptest-core-gbl-identity-gitops
+  terraform-apply-role: arn:aws:iam::yyyyyyyyyyyy:role/cptest-core-gbl-identity-gitops
+  terraform-version: 1.5.2
+  aws-region: us-east-2
+  enable-infracost: false
+  sort-by: .stack_slug
+  group-by: .stack_slug | split("-") | [.[0], .[2]] | join("-")  
+```
+
 ### Workflow example
 
 In this example drift will be remediated when user sets label `apply` to an issue.
@@ -99,7 +119,7 @@ jobs:
       contains(join(github.event.issue.labels.*.name, ','), 'apply')
     steps:
       - name: Remediate Drift
-        uses: cloudposse/github-action-atmos-terraform-drift-remediation@v1
+        uses: cloudposse/github-action-atmos-terraform-drift-remediation@v2
         with:
           issue-number: ${{ github.event.issue.number }}
           action: remediate
@@ -118,10 +138,57 @@ jobs:
       !contains(join(github.event.issue.labels.*.name, ','), 'remediated')
     steps:
       - name: Discard Drift
-        uses: cloudposse/github-action-atmos-terraform-drift-remediation@v1
+        uses: cloudposse/github-action-atmos-terraform-drift-remediation@v2
         with:
           issue-number: ${{ github.event.issue.number }}
           action: discard
+```
+
+### Migrate from `v1` to `v2`
+
+`v2` drop `component-path` variable. Now it fetches from `atmos.yaml` file automatically.
+
+`v2` moved variables from `inputs` to atmos gitops config path `./.github/atmos-gitops.yaml`
+
+|         name             |
+|--------------------------|
+| `atmos-version`          |
+| `atmos-config-path`      |
+| `terraform-state-bucket` |
+| `terraform-state-table`  |
+| `terraform-state-role`   |
+| `terraform-plan-role`    |
+| `terraform-apply-role`   |
+| `terraform-version`      |
+| `aws-region`             |
+| `enable-infracost`       |
+
+
+If you want `v2` having the same behaviour as `v1` you should create config `./.github/atmos-gitops.yaml` with the same variables as in `v1` inputs.
+
+```yaml
+  - name: Remediate Drift
+    uses: cloudposse/github-action-atmos-terraform-drift-remediation@v2
+    with:
+      issue-number: ${{ github.event.issue.number }}
+      action: remediate
+      atmos-gitops-config-path: ./.github/atmos-gitops.yaml  
+```
+
+same behaviour as
+
+```yaml
+  - name: Remediate Drift
+    uses: cloudposse/github-action-atmos-terraform-drift-remediation@v1
+    with:
+      issue-number: ${{ github.event.issue.number }}
+      action: remediate
+      atmos-config-path: "${{ github.workspace }}/rootfs/usr/local/etc/atmos/"
+      terraform-plan-role: "arn:aws:iam::111111111111:role/acme-core-gbl-identity-gitops"
+      terraform-state-bucket: "acme-core-ue2-auto-gitops"
+      terraform-state-role: "arn:aws:iam::999999999999:role/acme-core-ue2-auto-gitops-gha"
+      terraform-state-table: "acme-core-ue2-auto-gitops"
+      aws-region: "us-east-2"
 ```
 
 
@@ -136,16 +203,9 @@ jobs:
 | Name | Description | Default | Required |
 |------|-------------|---------|----------|
 | action | Drift remediation action. One of ['remediate', 'discard'] | remediate | false |
-| atmos-config-path | The path to the folder where atmos.yaml file is located | . | false |
-| atmos-version | Atmos version to use for vendoring. Default 'latest' | latest | false |
-| aws-region | AWS region for assuming identity. | us-east-1 | false |
+| atmos-gitops-config-path | The path to the atmos-gitops.yaml file | ./.github/config/atmos-gitops.yaml | false |
 | debug | Enable action debug mode. Default: 'false' | false | false |
 | issue-number | Issue Number | N/A | true |
-| terraform-apply-role | The AWS role to be used to apply Terraform. Required for action 'remediate'. | N/A | false |
-| terraform-state-bucket | The S3 Bucket where the planfiles are stored. Required for action 'remediate'. | N/A | false |
-| terraform-state-role | The AWS role to be used to retrieve the planfile from AWS. Required for action 'remediate'. | N/A | false |
-| terraform-state-table | The DynamoDB table where planfile metadata is stored. Required for action 'remediate'. | N/A | false |
-| terraform-version | The version of Terraform CLI to install. Instead of full version string you can also specify constraint string starting with "<" (for example `<1.13.0`) to install the latest version satisfying the constraint. A value of `latest` will install the latest version of Terraform CLI. Defaults to `latest`. | latest | false |
 | token | Used to pull node distributions for Atmos from Cloud Posse's GitHub repository. Since there's a default, this is typically not supplied by the user. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting. | ${{ github.server\_url == 'https://github.com' && github.token \|\| '' }} | false |
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -50,6 +50,26 @@ references:
     url: "https://github.com/cloudposse/github-action-atmos-terraform-apply"
 
 usage: |-
+  ### Config
+
+  The action expects the atmos gitops configuration file to be present in the repository in `./.github/atmos-gitops.yaml`.
+  The config should have the following structure:
+  
+  ```yaml
+    atmos-version: 1.45.3
+    atmos-config-path: ./rootfs/usr/local/etc/atmos/
+    terraform-state-bucket: cptest-core-ue2-auto-gitops
+    terraform-state-table: cptest-core-ue2-auto-gitops
+    terraform-state-role: arn:aws:iam::xxxxxxxxxxxx:role/cptest-core-ue2-auto-gitops-gha
+    terraform-plan-role: arn:aws:iam::yyyyyyyyyyyy:role/cptest-core-gbl-identity-gitops
+    terraform-apply-role: arn:aws:iam::yyyyyyyyyyyy:role/cptest-core-gbl-identity-gitops
+    terraform-version: 1.5.2
+    aws-region: us-east-2
+    enable-infracost: false
+    sort-by: .stack_slug
+    group-by: .stack_slug | split("-") | [.[0], .[2]] | join("-")  
+  ```
+  
   ### Workflow example
 
   In this example drift will be remediated when user sets label `apply` to an issue.
@@ -77,7 +97,7 @@ usage: |-
         contains(join(github.event.issue.labels.*.name, ','), 'apply')
       steps:
         - name: Remediate Drift
-          uses: cloudposse/github-action-atmos-terraform-drift-remediation@v1
+          uses: cloudposse/github-action-atmos-terraform-drift-remediation@v2
           with:
             issue-number: ${{ github.event.issue.number }}
             action: remediate
@@ -96,11 +116,59 @@ usage: |-
         !contains(join(github.event.issue.labels.*.name, ','), 'remediated')
       steps:
         - name: Discard Drift
-          uses: cloudposse/github-action-atmos-terraform-drift-remediation@v1
+          uses: cloudposse/github-action-atmos-terraform-drift-remediation@v2
           with:
             issue-number: ${{ github.event.issue.number }}
             action: discard
   ```
+  
+  ### Migrate from `v1` to `v2`
+  
+  `v2` drop `component-path` variable. Now it fetches from `atmos.yaml` file automatically.
+  
+  `v2` moved variables from `inputs` to atmos gitops config path `./.github/atmos-gitops.yaml`
+  
+  |         name             |
+  |--------------------------|
+  | `atmos-version`          |
+  | `atmos-config-path`      |
+  | `terraform-state-bucket` |
+  | `terraform-state-table`  |
+  | `terraform-state-role`   |
+  | `terraform-plan-role`    |
+  | `terraform-apply-role`   |
+  | `terraform-version`      |
+  | `aws-region`             |
+  | `enable-infracost`       |
+  
+  
+  If you want `v2` having the same behaviour as `v1` you should create config `./.github/atmos-gitops.yaml` with the same variables as in `v1` inputs.
+  
+  ```yaml
+    - name: Remediate Drift
+      uses: cloudposse/github-action-atmos-terraform-drift-remediation@v2
+      with:
+        issue-number: ${{ github.event.issue.number }}
+        action: remediate
+        atmos-gitops-config-path: ./.github/atmos-gitops.yaml  
+  ```
+  
+  same behaviour as
+  
+  ```yaml
+    - name: Remediate Drift
+      uses: cloudposse/github-action-atmos-terraform-drift-remediation@v1
+      with:
+        issue-number: ${{ github.event.issue.number }}
+        action: remediate
+        atmos-config-path: "${{ github.workspace }}/rootfs/usr/local/etc/atmos/"
+        terraform-plan-role: "arn:aws:iam::111111111111:role/acme-core-gbl-identity-gitops"
+        terraform-state-bucket: "acme-core-ue2-auto-gitops"
+        terraform-state-role: "arn:aws:iam::999999999999:role/acme-core-ue2-auto-gitops-gha"
+        terraform-state-table: "acme-core-ue2-auto-gitops"
+        aws-region: "us-east-2"
+  ```
+  
 
 include:
   - "docs/github-action.md"

--- a/README.yaml
+++ b/README.yaml
@@ -70,6 +70,9 @@ usage: |-
     group-by: .stack_slug | split("-") | [.[0], .[2]] | join("-")  
   ```
   
+  > [!IMPORTANT]
+  > **Please note!** the `terraform-state-*` parameters refer to the S3 Bucket and corresponding meta storage DynamoDB table used to store the Terraform Plan files, and not the "Terraform State". These parameters will be renamed in a subsequent release.  
+  
   ### Workflow example
 
   In this example drift will be remediated when user sets label `apply` to an issue.
@@ -97,17 +100,12 @@ usage: |-
         contains(join(github.event.issue.labels.*.name, ','), 'apply')
       steps:
         - name: Remediate Drift
-          uses: cloudposse/github-action-atmos-terraform-drift-remediation@v2
+          uses: cloudposse/github-action-atmos-terraform-drift-remediation@v1
           with:
             issue-number: ${{ github.event.issue.number }}
             action: remediate
-            atmos-config-path: "${{ github.workspace }}/rootfs/usr/local/etc/atmos/"
-            terraform-plan-role: "arn:aws:iam::111111111111:role/acme-core-gbl-identity-gitops"
-            terraform-state-bucket: "acme-core-ue2-auto-gitops"
-            terraform-state-role: "arn:aws:iam::999999999999:role/acme-core-ue2-auto-gitops-gha"
-            terraform-state-table: "acme-core-ue2-auto-gitops"
-            aws-region: "us-east-2"
-
+            atmos-gitops-config-path: ./.github/config/atmos-gitops.yaml
+  
     discard-drift:
       runs-on: ubuntu-latest
       name: Discard Drift
@@ -116,18 +114,18 @@ usage: |-
         !contains(join(github.event.issue.labels.*.name, ','), 'remediated')
       steps:
         - name: Discard Drift
-          uses: cloudposse/github-action-atmos-terraform-drift-remediation@v2
+          uses: cloudposse/github-action-atmos-terraform-drift-remediation@v1
           with:
             issue-number: ${{ github.event.issue.number }}
             action: discard
+            atmos-gitops-config-path: ./.github/config/atmos-gitops.yaml    
   ```
   
-  ### Migrating from `v1` to `v2`
+  ### Migrating from `v0` to `v1`
   
-  `v2` drop `component-path` variable. Now it fetches from `atmos.yaml` file automatically.
-  
-  `v2` moved variables from `inputs` to atmos gitops config path `./.github/config/atmos-gitops.yaml`
-  
+  1.  `v2` drops the `component-path` variable and instead fetches if directly from the [`atmos.yaml` file](https://atmos.tools/cli/configuration/) automatically. Simply remove the `component-path` argument from your invocations of the `cloudposse/github-action-atmos-terraform-plan` action.
+  2.  `v2` moves most of the `inputs` to the Atmos GitOps config path `./.github/config/atmos-gitops.yaml`. Simply create this file, transfer your settings to it, then remove the corresponding arguments from your invocations of the `cloudposse/github-action-atmos-terraform-plan` action.  
+
   |         name             |
   |--------------------------|
   | `atmos-version`          |
@@ -142,22 +140,22 @@ usage: |-
   | `enable-infracost`       |
   
   
-  If you want the same behavior in `v2`  as in`v1` you should create config `./.github/config/atmos-gitops.yaml` with the same variables as in `v1` inputs.
+  If you want the same behavior in `v1`  as in`v0` you should create config `./.github/config/atmos-gitops.yaml` with the same variables as in `v0` inputs.
   
   ```yaml
     - name: Remediate Drift
-      uses: cloudposse/github-action-atmos-terraform-drift-remediation@v2
+      uses: cloudposse/github-action-atmos-terraform-drift-remediation@v1
       with:
         issue-number: ${{ github.event.issue.number }}
         action: remediate
         atmos-gitops-config-path: ./.github/config/atmos-gitops.yaml  
   ```
   
-  same behaviour as
+   Which would produce the same behavior as in `v0`, doing this:
   
   ```yaml
     - name: Remediate Drift
-      uses: cloudposse/github-action-atmos-terraform-drift-remediation@v1
+      uses: cloudposse/github-action-atmos-terraform-drift-remediation@v0
       with:
         issue-number: ${{ github.event.issue.number }}
         action: remediate

--- a/README.yaml
+++ b/README.yaml
@@ -52,7 +52,7 @@ references:
 usage: |-
   ### Config
 
-  The action expects the atmos gitops configuration file to be present in the repository in `./.github/atmos-gitops.yaml`.
+  The action expects the atmos gitops configuration file to be present in the repository in `./.github/config/atmos-gitops.yaml`.
   The config should have the following structure:
   
   ```yaml
@@ -126,7 +126,7 @@ usage: |-
   
   `v2` drop `component-path` variable. Now it fetches from `atmos.yaml` file automatically.
   
-  `v2` moved variables from `inputs` to atmos gitops config path `./.github/atmos-gitops.yaml`
+  `v2` moved variables from `inputs` to atmos gitops config path `./.github/config/atmos-gitops.yaml`
   
   |         name             |
   |--------------------------|
@@ -142,7 +142,7 @@ usage: |-
   | `enable-infracost`       |
   
   
-  If you want `v2` having the same behaviour as `v1` you should create config `./.github/atmos-gitops.yaml` with the same variables as in `v1` inputs.
+  If you want `v2` having the same behaviour as `v1` you should create config `./.github/config/atmos-gitops.yaml` with the same variables as in `v1` inputs.
   
   ```yaml
     - name: Remediate Drift
@@ -150,7 +150,7 @@ usage: |-
       with:
         issue-number: ${{ github.event.issue.number }}
         action: remediate
-        atmos-gitops-config-path: ./.github/atmos-gitops.yaml  
+        atmos-gitops-config-path: ./.github/config/atmos-gitops.yaml  
   ```
   
   same behaviour as

--- a/README.yaml
+++ b/README.yaml
@@ -122,7 +122,7 @@ usage: |-
             action: discard
   ```
   
-  ### Migrate from `v1` to `v2`
+  ### Migrating from `v1` to `v2`
   
   `v2` drop `component-path` variable. Now it fetches from `atmos.yaml` file automatically.
   
@@ -142,7 +142,7 @@ usage: |-
   | `enable-infracost`       |
   
   
-  If you want `v2` having the same behaviour as `v1` you should create config `./.github/config/atmos-gitops.yaml` with the same variables as in `v1` inputs.
+  If you want the same behavior in `v2`  as in`v1` you should create config `./.github/config/atmos-gitops.yaml` with the same variables as in `v1` inputs.
   
   ```yaml
     - name: Remediate Drift

--- a/action.yml
+++ b/action.yml
@@ -12,34 +12,10 @@ inputs:
     description: "Drift remediation action. One of ['remediate', 'discard']"
     required: false
     default: 'remediate'
-  terraform-apply-role:
-    description: "The AWS role to be used to apply Terraform. Required for action 'remediate'."
+  atmos-gitops-config-path:
+    description: The path to the atmos-gitops.yaml file
     required: false
-  terraform-state-role:
-    description: "The AWS role to be used to retrieve the planfile from AWS. Required for action 'remediate'."
-    required: false
-  terraform-state-bucket:
-    description: "The S3 Bucket where the planfiles are stored. Required for action 'remediate'."
-    required: false
-  terraform-state-table:
-    description: "The DynamoDB table where planfile metadata is stored. Required for action 'remediate'."
-    required: false
-  aws-region:
-    description: "AWS region for assuming identity."
-    required: false
-    default: "us-east-1"
-  atmos-version:
-    description: "Atmos version to use for vendoring. Default 'latest'"
-    required: false
-    default: 'latest'
-  atmos-config-path:
-    description: The path to the folder where atmos.yaml file is located
-    required: false
-    default: '.'
-  terraform-version:
-    description: 'The version of Terraform CLI to install. Instead of full version string you can also specify constraint string starting with "<" (for example `<1.13.0`) to install the latest version satisfying the constraint. A value of `latest` will install the latest version of Terraform CLI. Defaults to `latest`.'
-    default: 'latest'
-    required: false
+    default: ./.github/config/atmos-gitops.yaml
   debug:
     description: "Enable action debug mode. Default: 'false'"
     default: 'false'
@@ -90,7 +66,6 @@ runs:
 
             core.setOutput('component', metadata.component);
             core.setOutput('stack', metadata.stack);
-            core.setOutput('component-path', metadata.componentPath);
             core.setOutput('commit-sha', metadata.commitSHA);
           } catch (error) {
             core.setFailed(error.message);
@@ -99,21 +74,12 @@ runs:
     - name: Atmos Apply
       if: env.ACTION == 'remediate'
       id: atmos-apply
-      uses: cloudposse/github-action-atmos-terraform-apply@v0
+      uses: cloudposse/github-action-atmos-terraform-apply@incapsulate-configs
       with:
         component: ${{ steps.metadata.outputs.component }}
         stack: ${{ steps.metadata.outputs.stack }}
-        component-path: ${{ steps.metadata.outputs.component-path }}
         sha: ${{ steps.metadata.outputs.commit-sha }}
-        terraform-apply-role: ${{ inputs.terraform-apply-role }}
-        terraform-state-bucket: ${{ inputs.terraform-state-bucket }}
-        terraform-state-role: ${{ inputs.terraform-state-role }}
-        terraform-state-table: ${{ inputs.terraform-state-table }}
-        aws-region: ${{ inputs.aws-region }}
-        token: ${{ inputs.token }}
-        atmos-version: ${{ inputs.atmos-version }}
-        atmos-config-path: ${{ inputs.atmos-config-path }}
-        terraform-version: ${{ inputs.terraform-version }}
+        atmos-gitops-config-path: ${{ inputs.atmos-gitops-config-path }}
         debug: ${{ inputs.debug }}
 
     - name: Check If GitHub Actions is Enabled For Component

--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,7 @@ runs:
     - name: Atmos Apply
       if: env.ACTION == 'remediate'
       id: atmos-apply
-      uses: cloudposse/github-action-atmos-terraform-apply@incapsulate-configs
+      uses: cloudposse/github-action-atmos-terraform-apply@v1
       with:
         component: ${{ steps.metadata.outputs.component }}
         stack: ${{ steps.metadata.outputs.stack }}

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -5,16 +5,9 @@
 | Name | Description | Default | Required |
 |------|-------------|---------|----------|
 | action | Drift remediation action. One of ['remediate', 'discard'] | remediate | false |
-| atmos-config-path | The path to the folder where atmos.yaml file is located | . | false |
-| atmos-version | Atmos version to use for vendoring. Default 'latest' | latest | false |
-| aws-region | AWS region for assuming identity. | us-east-1 | false |
+| atmos-gitops-config-path | The path to the atmos-gitops.yaml file | ./.github/config/atmos-gitops.yaml | false |
 | debug | Enable action debug mode. Default: 'false' | false | false |
 | issue-number | Issue Number | N/A | true |
-| terraform-apply-role | The AWS role to be used to apply Terraform. Required for action 'remediate'. | N/A | false |
-| terraform-state-bucket | The S3 Bucket where the planfiles are stored. Required for action 'remediate'. | N/A | false |
-| terraform-state-role | The AWS role to be used to retrieve the planfile from AWS. Required for action 'remediate'. | N/A | false |
-| terraform-state-table | The DynamoDB table where planfile metadata is stored. Required for action 'remediate'. | N/A | false |
-| terraform-version | The version of Terraform CLI to install. Instead of full version string you can also specify constraint string starting with "<" (for example `<1.13.0`) to install the latest version satisfying the constraint. A value of `latest` will install the latest version of Terraform CLI. Defaults to `latest`. | latest | false |
 | token | Used to pull node distributions for Atmos from Cloud Posse's GitHub repository. Since there's a default, this is typically not supplied by the user. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting. | ${{ github.server\_url == 'https://github.com' && github.token \|\| '' }} | false |
 
 


### PR DESCRIPTION
## what
* Incapsulate configs

### Migrating from `v1` to `v2`

`v2` drop `component-path` variable. Now it fetches from `atmos.yaml` file automatically.

`v2` moved variables from `inputs` to atmos gitops config path `./.github/config/atmos-gitops.yaml`

|         name             |
|--------------------------|
| `atmos-version`          |
| `atmos-config-path`      |
| `terraform-state-bucket` |
| `terraform-state-table`  |
| `terraform-state-role`   |
| `terraform-plan-role`    |
| `terraform-apply-role`   |
| `terraform-version`      |
| `aws-region`             |
| `enable-infracost`       |


If you want the same behavior in `v2`  as in`v1` you should create config `./.github/config/atmos-gitops.yaml` with the same variables as in `v1` inputs.

```yaml
  - name: Remediate Drift
    uses: cloudposse/github-action-atmos-terraform-drift-remediation@v2
    with:
      issue-number: ${{ github.event.issue.number }}
      action: remediate
      atmos-gitops-config-path: ./.github/config/atmos-gitops.yaml  
```

same behaviour as

```yaml
  - name: Remediate Drift
    uses: cloudposse/github-action-atmos-terraform-drift-remediation@v1
    with:
      issue-number: ${{ github.event.issue.number }}
      action: remediate
      atmos-config-path: "${{ github.workspace }}/rootfs/usr/local/etc/atmos/"
      terraform-plan-role: "arn:aws:iam::111111111111:role/acme-core-gbl-identity-gitops"
      terraform-state-bucket: "acme-core-ue2-auto-gitops"
      terraform-state-role: "arn:aws:iam::999999999999:role/acme-core-ue2-auto-gitops-gha"
      terraform-state-table: "acme-core-ue2-auto-gitops"
      aws-region: "us-east-2"
```
