### PR TITLE
Fix: Don't Close PRs if Terraform Apply Fails

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -85,6 +85,7 @@ runs:
     - name: Check If GitHub Actions is Enabled For Component
       shell: bash
       run: |
+        echo "atmos-apply result: ${{ steps.atmos-apply.outputs.status }}"
         apply_succeeded=${{ steps.atmos-apply.outputs.status != 'succeeded' }}
         echo "APPLY_SUCCEEDED: $apply_succeeded"
         echo "APPLY_SUCCEEDED=$apply_succeeded" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ runs:
       shell: bash
       run: |
         echo "atmos-apply result: ${{ steps.atmos-apply.outputs.status }}"
-        apply_succeeded=${{ steps.atmos-apply.outputs.status != 'succeeded' }}
+        apply_succeeded=${{ steps.atmos-apply.outputs.status == 'succeeded' }}
         echo "APPLY_SUCCEEDED: $apply_succeeded"
         echo "APPLY_SUCCEEDED=$apply_succeeded" >> $GITHUB_ENV
 


### PR DESCRIPTION
## what
- Fix apply step result

## why
- Don't close a PR if the Terraform apply fails
- This action was previously always returning true, even when the apply step failed. Then I accidentally pushed directly to main with the reverse so this now always fails.
- I've set up branch protection to prevent that in the future and then fixed it with this PR

## references
- https://github.com/cloudposse/github-action-atmos-terraform-drift-remediation/commit/f5c9fcb797e0dc52e8305a80133d72d97601f905

