### PR TITLE
Disable process functions

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -53,7 +53,8 @@ usage: |-
   ### Config
 
   > [!IMPORTANT]
-  > **Please note!** This GitHub Action only works with `atmos >= 1.99.0`.
+  > **Please note!** This GitHub Action only works with `atmos >= 1.158.0`.
+  > If you are using `atmos >= 1.99.0, < 1.158.0` please use `v3` version of this action.   
   > If you are using `atmos >= 1.63.0, < 1.99.0` please use `v2` version of this action.  
   > If you are using `atmos < 1.63.0` please use `v1` version of this action.
 
@@ -215,6 +216,12 @@ usage: |-
             action: discard
             atmos-gitops-config-path: ./.github/config/atmos-gitops.yaml    
   ```
+
+  ### Migrating from `v3` to `v4`
+  
+  The notable changes in `v4` are:
+  - `v4` works only with `atmos >= 1.158.0`
+  - `v4` supports atnos `templates` and `functions`
 
   ### Migrating from `v2` to `v3`
   

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   atmos-version:
     description: The version of atmos to install
     required: false
-    default: ">= 1.99.0"
+    default: ">= 1.158.0"
   atmos-config-path:
     description: The path to the atmos.yaml file
     required: true
@@ -80,7 +80,7 @@ runs:
     - name: Atmos Apply
       if: env.ACTION == 'remediate'
       id: atmos-apply
-      uses: cloudposse/github-action-atmos-terraform-apply@v3
+      uses: cloudposse/github-action-atmos-terraform-apply@v4
       with:
         component: ${{ steps.metadata.outputs.component }}
         stack: ${{ steps.metadata.outputs.stack }}


### PR DESCRIPTION
## Breaking Change!
* Requires `atmos >= 1.158.0`. Will fail on older version

## what
* Disable process functions for `cloudposse/github-action-atmos-get-setting`

## why
* `process-functions` requires terraform. Which we install after fetching the version
* `process-functions` can cause an issue where cached terraform versions conflict with the version we want to install
* `atmos < 1.158.0` not not support flag `--process-functions`



